### PR TITLE
Migrate to Simplifile 2.x

### DIFF
--- a/gleam.toml
+++ b/gleam.toml
@@ -15,7 +15,7 @@ gleam = ">= 1.1.0"
 
 [dependencies]
 gleam_stdlib = "~> 0.34 or ~> 1.0"
-simplifile = "~> 1.2"
+simplifile = "~> 2.0"
 gleam_community_path = "~> 0.1"
 
 [dev-dependencies]

--- a/manifest.toml
+++ b/manifest.toml
@@ -2,14 +2,15 @@
 # You typically do not need to edit this file
 
 packages = [
+  { name = "filepath", version = "1.0.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "filepath", source = "hex", outer_checksum = "EFB6FF65C98B2A16378ABC3EE2B14124168C0CE5201553DE652E2644DCFDB594" },
   { name = "gleam_community_path", version = "0.1.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_community_path", source = "hex", outer_checksum = "916C2829E2ED81036BBA180CFD5E8633D05E25C304FDF6E3BC8A048459B89725" },
   { name = "gleam_stdlib", version = "0.36.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "C0D14D807FEC6F8A08A7C9EF8DFDE6AE5C10E40E21325B2B29365965D82EB3D4" },
   { name = "gleeunit", version = "1.0.2", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "D364C87AFEB26BDB4FB8A5ABDE67D635DC9FA52D6AB68416044C35B096C6882D" },
-  { name = "simplifile", version = "1.5.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "simplifile", source = "hex", outer_checksum = "EB9AA8E65E5C1E3E0FDCFC81BC363FD433CB122D7D062750FFDF24DE4AC40116" },
+  { name = "simplifile", version = "2.1.0", build_tools = ["gleam"], requirements = ["filepath", "gleam_stdlib"], otp_app = "simplifile", source = "hex", outer_checksum = "BDD04F5D31D6D34E2EDFAEF0B68A6297AEC939888C3BFCE61133DE13857F6DA2" },
 ]
 
 [requirements]
 gleam_community_path = { version = "~> 0.1" }
 gleam_stdlib = { version = "~> 0.34 or ~> 1.0" }
 gleeunit = { version = "~> 1.0" }
-simplifile = { version = "~> 1.2" }
+simplifile = { version = "~> 2.0" }

--- a/src/fswalk.gleam
+++ b/src/fswalk.gleam
@@ -3,7 +3,7 @@ import gleam/list
 import gleam/option.{type Option, None, Some}
 import gleam/result
 import gleam_community/path
-import simplifile.{type FileError, read_directory, verify_is_directory}
+import simplifile.{type FileError, is_directory, read_directory}
 
 @internal
 pub type Non
@@ -83,7 +83,7 @@ fn to_entry(path: path.Path) -> Entry {
   Entry(
     filename,
     stat: Stat(
-      is_directory: verify_is_directory(filename)
+      is_directory: is_directory(filename)
       |> result.unwrap(or: False),
     ),
   )
@@ -111,7 +111,7 @@ fn walk_path(
         list.fold(paths, #([], []), fn(acc, it) {
           let entry = to_entry(it)
           let is_dir =
-            verify_is_directory(path.to_string(it))
+            is_directory(path.to_string(it))
             |> result.unwrap(or: False)
           #([entry, ..acc.0], case is_dir {
             True -> [entry, ..acc.1]


### PR DESCRIPTION
Hi there,
This update to the Simplifile dependency makes it possible to use this library on more recent projects.

I'm not sure what semver's policy is in this case as it changes the major version of Simplifile. Does this justify a 4.0 version?